### PR TITLE
Soften "untrusted" to "unknown" signer in UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The extension automatically scans the current HTML page for C2PA assets and vali
 |                                                                  |                                                                                     |
 |------------------------------------------------------------------|-------------------------------------------------------------------------------------|
 | <img src="./public/icons/cr.svg" alt="valid icon" width="50">    | a valid asset, i.e. a well-formed C2PA manifest signed by a trusted issuer          |
-| <img src="./public/icons/cr!.svg" alt="warning icon" width="50"> | an untrusted asset, i.e., a well-formed C2PA manifest signed by an untrusted issuer |
+| <img src="./public/icons/cr!.svg" alt="warning icon" width="50"> | an untrusted asset, i.e., a well-formed C2PA manifest signed by an unknown issuer |
 | <img src="./public/icons/crx.svg" alt="invalid icon" width="50"> | a invalid asset                                                                     |
 
 See the [C2PA specification](https://c2pa.org/specifications/specifications/2.0/specs/C2PA_Specification.html#_statements_by_a_validator) for the definition of well-formed manifests and trusted signers.

--- a/src/webComponents.ts
+++ b/src/webComponents.ts
@@ -390,7 +390,7 @@ export class C2paOverlay extends LitElement {
       result.push(html`
       <div id="untrusted">
         <img id="untrustedIcon" src="icons/!.svg">
-        <div id="untrustedText"><span class="bold">${this.signer}</span> is untrusted</div>
+        <div id="untrustedText"><span class="bold">${this.signer}</span> is unknown</div>
       </div>`
       )
     }
@@ -426,7 +426,7 @@ export class C2paOverlay extends LitElement {
               <img class="thumbnail" id="thumbnail" src="${this.thumbprintUrl ?? chrome.runtime.getURL('icons/movie.svg')}">
           </div>
           <div>
-              <div id="divSigned">${mediaType} ${manifestCount > 1 ? 'last ' : ''}signed by ${trusted ? '' : html`<span class="bold">untrusted</span> entity `}<span class="bold">${this.signer}</span> 
+              <div id="divSigned">${mediaType} ${manifestCount > 1 ? 'last ' : ''}signed by ${trusted ? '' : html`<span class="bold">unknown</span> entity `}<span class="bold">${this.signer}</span> 
                   <div class="image-container">
                       <img class="certIcon clickable" src="icons/cert.svg" alt="Cert Icon">
                       <div class="popover-content">

--- a/test/unit-tests.html
+++ b/test/unit-tests.html
@@ -42,7 +42,7 @@
 
     <h2>Untrusted assets</h2>
 
-    <p>This file is valid (well-formed C2PA manifest) but the signer is untrusted (unknown).</p>
+    <p>This file is valid (well-formed C2PA manifest) but the signer is unknown.</p>
     <img src="./media/cards_untrusted.jpg" alt="untrusted JPG" height="300">
 
     <h2>Invalid assets</h2>


### PR DESCRIPTION
Still keeping "untrusted" in scripts and tests.