### PR TITLE
Fix x509 cert-chain retrieval when tstTokens are used

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT license.
  */
 
-import { arrayBufferToBase64, blobToDataURL, isKeyedObject, isObject, base64ToArrayBuffer, dataURLtoBlob } from './utils.js'
+import { bytesToBase64, blobToDataURL, isKeyedObject, isObject, base64ToArrayBuffer, dataURLtoBlob } from './utils.js'
 
 export const REFERENCE_ID = '__ref'
 export const CIRCLE_ID = '__circle'
@@ -41,7 +41,7 @@ async function _serialize (obj: unknown, alreadySerialized: WeekMapWithCounter):
   }
 
   if (obj instanceof ArrayBuffer) {
-    const base64 = arrayBufferToBase64(obj)
+    const base64 = bytesToBase64(new Uint8Array(obj))
     result = { type: 'ArrayBuffer', data: base64 }
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,9 +26,8 @@ export async function blobToDataURL (blob: Blob): Promise<string> {
   })
 }
 
-export function arrayBufferToBase64 (buffer: ArrayBuffer): string {
+export function bytesToBase64 (bytes: Uint8Array): string {
   let binary = ''
-  const bytes = new Uint8Array(buffer)
   for (let i = 0; i < bytes.byteLength; i++) {
     binary += String.fromCharCode(bytes[i])
   }


### PR DESCRIPTION
- Fix issue where the certificate chain is in protected header and cbor encoded when the timestamp is used
- Renamed bytesToBase64 function