### PR TITLE
Display trust list info URL for unknown signer (prototype)

### DIFF
--- a/src/c2pa.ts
+++ b/src/c2pa.ts
@@ -18,6 +18,7 @@ export interface C2paResult extends C2paReadResult {
   url: string
   certChain: CertificateWithThumbprint[] | null
   trustList: TrustListMatch | null
+  trustListUrl: string | null
   l2: L2ManifestStore
   editsAndActivity: TranslatedDictionaryCategory[] | null
 }
@@ -83,6 +84,10 @@ async function _validateUrl (url: string): Promise<C2paResult | C2paError> {
 
   const trustListMatch = await checkTrustListInclusionRemote(certChain)
 
+  const rcgi: any = c2paResult.manifestStore?.activeManifest?.claimGeneratorInfo[0]; // casting to "any" since 'trust_list_info' does not exist on type 'ResolvedClaimGeneratorInfo'
+  const trustListUrl = rcgi?.trust_list_info ?? undefined;
+  console.log("trustListUrl", trustListUrl)
+
   const serializedIssuer = await serialize(certChain[0].issuer) as Certificate
   console.debug('Issuer: ', serializedIssuer)
 
@@ -90,6 +95,7 @@ async function _validateUrl (url: string): Promise<C2paResult | C2paError> {
     ...c2paResult,
     url,
     trustList: trustListMatch,
+    trustListUrl: trustListUrl,
     certChain,
     l2,
     editsAndActivity

--- a/src/webComponents.ts
+++ b/src/webComponents.ts
@@ -279,6 +279,8 @@ export class C2paOverlay extends LitElement {
 
   private trustList?: string
 
+  private trustListUrl?: string
+
   private status?: { errors: boolean, trusted: boolean }
 
   @property({ type: Boolean })
@@ -338,6 +340,8 @@ export class C2paOverlay extends LitElement {
     this.signer = newValue?.manifestStore?.activeManifest.signatureInfo?.issuer ?? 'unknown entity'
 
     this.trustList = newValue?.trustList?.tlInfo.name ?? 'unknown'
+  
+    this.trustListUrl = newValue?.trustListUrl ?? undefined
   }
 
   private setStatus (c2paResult: C2paResult): { errors: boolean, trusted: boolean } {
@@ -378,6 +382,11 @@ export class C2paOverlay extends LitElement {
         <div id="untrustedText"><span class="bold">${this.signer}</span> is unknown</div>
       </div>`
       )
+      if (this.trustListUrl != null) {
+        result.push(html`
+        <div>${this.signer} claims to be part of this <a href="${this.trustListUrl}" target="_blank">trust list</a>.</div>
+        `)
+      }
     }
 
     return result


### PR DESCRIPTION
Extract and display trust list info from claim generator info if present; display it as a hint for unknown signers.