### PR TITLE
Add trust anchor to trust list store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,12 @@
 - Enable context menu validation and added auto-scan option
 - Dynamic icon updates when in web view
 - Create chrome and firefox dist zip artifact
+- Add individual trust anchors list
 
 ## v0.1.2
 
-- Added support for Firefox
-- Added option to scan all media on a page
+- Add support for Firefox
+- Add option to scan all media on a page
 - Various updates
 
 ## v0.1.1

--- a/public/popup.html
+++ b/public/popup.html
@@ -46,6 +46,8 @@
                         href="https://github.com/christianpaquin/c2pa-explorations/blob/main/trust-lists/trust-lists.md#list-of-x509-certificates"
                         target="_blank">specification</a>.</p>
                 <input type="file" id="trust-list-input" accept=".json">
+                <p>Import a X.509 certificate trust anchor.</p>
+                <input type="file" id="trust-anchor-input" accept=".pem,.crt">
                 <div id="trust-list-info"></div>
             </div>
             <br>

--- a/src/c2pa.ts
+++ b/src/c2pa.ts
@@ -4,7 +4,7 @@
  */
 
 import { createC2pa, type C2pa, type C2paReadResult, selectEditsAndActivity, type TranslatedDictionaryCategory, type ManifestStore, type ManifestMap } from 'c2pa'
-import { type CertificateWithThumbprint, extractCertChain } from './certs/certs.js'
+import { type CertificateInfoExtended, extractCertChain } from './certs/certs.js'
 import { type TrustListMatch } from './trustlistProxy.js'
 import { AWAIT_ASYNC_RESPONSE, MSG_C2PA_VALIDATE_URL, type MSG_PAYLOAD } from './constants.js'
 import { blobToDataURL } from './utils.js'
@@ -15,7 +15,7 @@ let c2pa: C2pa | null = null
 
 export interface C2paResult extends ExtensionC2paResult {
   url: string
-  certChain: CertificateWithThumbprint[] | null
+  certChain: CertificateInfoExtended[] | null
   trustList: TrustListMatch | null
   editsAndActivity: TranslatedDictionaryCategory[] | null
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -41,6 +41,7 @@ export const REMOTE_VALIDATION_LINK = 'https://contentintegrity.microsoft.com/ch
 export const AWAIT_ASYNC_RESPONSE = true
 export const AUTO_SCAN_DEFAULT = process.env.AUTO_SCAN?.toLowerCase() === 'true' || false
 export const TRUSTLIST_UPDATE_INTERVAL = 1440 /* 24 hours */
+export const LOCAL_TRUST_ANCHOR_LIST_NAME = 'Local Trust Anchors'
 
 export const CR_ICON_SIZE = '2em'
 export const CR_ICON_Z_INDEX = 10000

--- a/src/trustlist.ts
+++ b/src/trustlist.ts
@@ -204,6 +204,9 @@ export async function addTrustAnchor(pemCert: string): Promise<void> {
       console.debug(`Adding new entity ${entity.name}`)
       anchorTL?.entities.push(entity)
     }
+    // update the global trust list
+    const index = globalTrustLists.indexOf(anchorTL)
+    globalTrustLists[index] = anchorTL
   }
 
   storeUpdatedTrustLists(`Trust anchor added to local trust anchor list: ${entity.name}`)

--- a/src/trustlist.ts
+++ b/src/trustlist.ts
@@ -117,9 +117,8 @@ async function processDownloadedTrustList (tl: TrustList): Promise<void> {
 /**
  * Returns the JWK key type `kty` corresponding to a supported signature alg
  */
-function sigAlgToKeyType(sigAlg: string): ValidKeyTypes {
-  let sigAlgLC = sigAlg.toLowerCase().replace('-', '')
-  sigAlgLC = sigAlgLC
+function sigAlgToKeyType (sigAlg: string): ValidKeyTypes {
+  const sigAlgLC = sigAlg.toLowerCase().replace('-', '')
   if (sigAlgLC === 'sha256withrsaencryption' || sigAlgLC === 'sha384withrsaencryption' || sigAlgLC === 'sha512withrsaencryption' || sigAlgLC === 'idrsassapss') {
     return 'RSA'
   } else if (sigAlgLC === 'ecdsawithsha256' || sigAlgLC === 'ecdsawithsha384' || sigAlgLC === 'ecdsawithsha512') {
@@ -134,7 +133,7 @@ function sigAlgToKeyType(sigAlg: string): ValidKeyTypes {
 /**
  * Stores the updated trust lists and notify the tab of the update
  */
-function storeUpdatedTrustLists(message?: string) {
+function storeUpdatedTrustLists (message?: string): void {
   chrome.storage.local.set({ trustList: globalTrustLists }, function () {
     console.debug(message)
   })
@@ -142,17 +141,17 @@ function storeUpdatedTrustLists(message?: string) {
 }
 
 /**
- * Adds a trust anchor to the built-in trust anchors list, returns the corresponding trust list info or throws an error 
+ * Adds a trust anchor to the built-in trust anchors list, returns the corresponding trust list info or throws an error
  */
-export async function addTrustAnchor(pemCert: string): Promise<void> {
+export async function addTrustAnchor (pemCert: string): Promise<void> {
   console.debug('addTrustAnchor called')
-  if (!pemCert || typeof pemCert !== 'string') {
+  if (pemCert == null || typeof pemCert !== 'string') {
     throw new Error('Invalid trust anchor')
   }
 
   const derCert = PEMtoDER(pemCert)
   const cert = await createCertificateFromDer(derCert)
-  console.debug(`cert`, cert)
+  console.debug('cert', cert)
   const x5c = bytesToBase64(derCert)
 
   // create an entity to add to the built-in trust anchor list
@@ -161,25 +160,25 @@ export async function addTrustAnchor(pemCert: string): Promise<void> {
   const entity: TrustedEntity = {
     name: DN,
     display_name: DN,
-    contact: "", // n/a
+    contact: '', // n/a
     isCA: true,
     jwks: {
-        keys: [
-            {
-                kty: kty,
-                x5c: [
-                    x5c
-                ],
-                'x5t#S256': cert.sha256Thumbprint
-            }
-        ]
+      keys: [
+        {
+          kty,
+          x5c: [
+            x5c
+          ],
+          'x5t#S256': cert.sha256Thumbprint
+        }
+      ]
     }
   }
   console.debug(`created trust anchor entity ${entity.name}`, entity)
 
   // find the local trust anchor list
   const anchorTL = globalTrustLists.find(tl => tl.name === 'Local Trust Anchors')
-  if (!anchorTL)  {
+  if (anchorTL == null) {
     // list doesn't exist; create it
     console.debug('Local Trust Anchors trust list not found; creating it')
     const tl: TrustList = {
@@ -196,7 +195,7 @@ export async function addTrustAnchor(pemCert: string): Promise<void> {
     console.debug('Updating local Trust Anchors trust list')
     // add or replace the entity in the list
     const existingEntity = anchorTL.entities.find(e => e.name === entity.name)
-    if (existingEntity) {
+    if (existingEntity != null) {
       console.debug(`Replacing existing entity ${entity.name}`)
       const index = anchorTL.entities.indexOf(existingEntity)
       anchorTL.entities[index] = entity
@@ -211,7 +210,6 @@ export async function addTrustAnchor(pemCert: string): Promise<void> {
 
   storeUpdatedTrustLists(`Trust anchor added to local trust anchor list: ${entity.name}`)
 }
-
 
 /**
  * Adds a trust list, returns the corresponding trust list info or throws an error

--- a/src/trustlistProxy.ts
+++ b/src/trustlistProxy.ts
@@ -3,12 +3,12 @@
  *  Licensed under the MIT license.
  */
 
-import { type CertificateWithThumbprint } from './certs/certs'
+import { type CertificateInfoExtended } from './certs/certs'
 import { MSG_ADD_TRUSTLIST, MSG_CHECK_TRUSTLIST_INCLUSION, MSG_GET_TRUSTLIST_INFOS, MSG_REMOVE_TRUSTLIST } from './constants'
 import { type TrustList, type TrustListInfo, type TrustListMatch } from './trustlist'
 export { type TrustListMatch, type TrustList, type TrustListInfo } from './trustlist'
 
-export async function checkTrustListInclusion (certChain: CertificateWithThumbprint[]): Promise<TrustListMatch | null> {
+export async function checkTrustListInclusion (certChain: CertificateInfoExtended[]): Promise<TrustListMatch | null> {
   return await chrome.runtime.sendMessage({ action: MSG_CHECK_TRUSTLIST_INCLUSION, data: certChain })
 }
 

--- a/src/webComponents.ts
+++ b/src/webComponents.ts
@@ -6,7 +6,7 @@
 import { LitElement, html, css, type TemplateResult } from 'lit'
 import { customElement, property } from 'lit/decorators.js'
 import { type ExtensionC2paIngredient, type C2paResult } from './c2pa'
-import { type CertificateWithThumbprint } from './certs/certs'
+import { type CertificateInfoExtended } from './certs/certs'
 import { MSG_L3_INSPECT_URL } from './constants'
 
 /*
@@ -627,7 +627,7 @@ const unknownSvg = 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.o
 
 const signSvg = 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20height%3D%2218%22%20viewBox%3D%220%200%2018%2018%22%20width%3D%2218%22%3E%20%20%3Cdefs%3E%20%20%20%20%3Cstyle%3E%20%20%20%20%20%20.fill%20%7B%20%20%20%20%20%20%20%20fill%3A%20%236E6E6E%3B%20%20%20%20%20%20%7D%20%20%20%20%3C%2Fstyle%3E%20%20%3C%2Fdefs%3E%20%20%3Ctitle%3ES%20Draw%2018%20N%3C%2Ftitle%3E%20%20%3Crect%20id%3D%22Canvas%22%20fill%3D%22%23ff13dc%22%20opacity%3D%220%22%20width%3D%2218%22%20height%3D%2218%22%20%2F%3E%3Cpath%20class%3D%22fill%22%20d%3D%22M10.227%2C4%2C2.542%2C11.686a.496.496%2C0%2C0%2C0-.1255.2105L1.0275%2C16.55c-.057.188.2295.425.3915.425a.15587.15587%2C0%2C0%2C0%2C.031-.003c.138-.032%2C3.9335-1.172%2C4.6555-1.389a.492.492%2C0%2C0%2C0%2C.2075-.125L14%2C7.772ZM5.7%2C14.658c-1.0805.3245-2.431.7325-3.3645%2C1.011L3.34%2C12.304Z%22%20%2F%3E%20%20%3Cpath%20class%3D%22fill%22%20d%3D%22M16.7835%2C4.1%2C13.9%2C1.216a.60751.60751%2C0%2C0%2C0-.433-.1765H13.45a.686.686%2C0%2C0%2C0-.4635.2035l-2.05%2C2.05L14.708%2C7.0645l2.05-2.05a.686.686%2C0%2C0%2C0%2C.2-.4415A.612.612%2C0%2C0%2C0%2C16.7835%2C4.1Z%22%20%2F%3E%3C%2Fsvg%3E'
 
-function certificateItems (certificates: CertificateWithThumbprint[]): IconTextItem[] {
+function certificateItems (certificates: CertificateInfoExtended[]): IconTextItem[] {
   return certificates.map((cert) => {
     // const parsedCert = parseCertificate(cert)
     return {


### PR DESCRIPTION
Adds the ability to add individual trust anchors to a local anchor trust list.

To test, from a fresh install, download the (zipped) [msft root CA cert ](https://github.com/microsoft/c2pa-extension-validator/files/15489978/msft_root.zip), add it as a trusted anchor ("Options" --> "Import X.509 cert"), and verify the [bing creator image](https://github.com/microsoft/c2pa-extension-validator/blob/main/test/media/bing_creator_cloud_surfing_puppy.jpg). 