### PR TITLE
Fix dynamic trust list updates

### DIFF
--- a/src/trustlistProxy.ts
+++ b/src/trustlistProxy.ts
@@ -3,14 +3,9 @@
  *  Licensed under the MIT license.
  */
 
-import { type CertificateInfoExtended } from './certs/certs'
-import { MSG_ADD_TRUSTLIST, MSG_CHECK_TRUSTLIST_INCLUSION, MSG_GET_TRUSTLIST_INFOS, MSG_REMOVE_TRUSTLIST } from './constants'
-import { type TrustList, type TrustListInfo, type TrustListMatch } from './trustlist'
+import { MSG_ADD_TRUSTLIST, MSG_GET_TRUSTLIST_INFOS, MSG_REMOVE_TRUSTLIST } from './constants'
+import { type TrustList, type TrustListInfo } from './trustlist'
 export { type TrustListMatch, type TrustList, type TrustListInfo } from './trustlist'
-
-export async function checkTrustListInclusion (certChain: CertificateInfoExtended[]): Promise<TrustListMatch | null> {
-  return await chrome.runtime.sendMessage({ action: MSG_CHECK_TRUSTLIST_INCLUSION, data: certChain })
-}
 
 export async function getTrustListInfos (): Promise<TrustListInfo[]> {
   return await chrome.runtime.sendMessage({ action: MSG_GET_TRUSTLIST_INFOS, data: undefined })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@
  */
 
 import 'dotenv/config'
-import { DEFAULT_MSG_TIMEOUT } from './constants'
+import { DEFAULT_MSG_TIMEOUT, type MSG_PAYLOAD } from './constants'
 
 export const DEBUG = process.env.NODE_ENV?.toUpperCase() !== 'PRODUCTION'
 
@@ -126,4 +126,19 @@ export function dataURLtoBlob (dataurl: string): Blob | null {
 
   // Create and return a Blob from the typed array
   return new Blob([u8arr], { type: mimeType })
+}
+
+export async function sendMessageToAllTabs (message: MSG_PAYLOAD): Promise<void> {
+  const tabs = await chrome.tabs.query({})
+  tabs.filter(tab => tab.id != null).forEach(function (tab) {
+    if (tab.id == null) {
+      return
+    }
+    void chrome.tabs.sendMessage(tab.id, message)
+  })
+}
+
+export async function getActiveTabId (): Promise<number | undefined> {
+  const tabs = await chrome.tabs.query({ active: true, currentWindow: true })
+  return tabs?.[0]?.id
 }

--- a/src/visible.ts
+++ b/src/visible.ts
@@ -95,9 +95,7 @@ function notIntersecting (mediaRecord: MediaRecord): void {
   observe(mediaRecord)
 }
 
-export function observe (
-  mediaRecord: MediaRecord
-): void {
+export function observe (mediaRecord: MediaRecord): void {
   _intersectionObserver.observe(mediaRecord.element)
 }
 


### PR DESCRIPTION
C2PA icons on web pages were not always being updated properly when the trustlist was updated in popup

- Now a trustlist update sends a message to each tab. Each tab loads the trustlist from local storage and then checks every known media element against the new trust list.
- Certchains no longer need to be messaged back to the background script.
- Fixed issue where only the active tab would get updated. Now all tabs will get updated.